### PR TITLE
tuple: silence gcc warning

### DIFF
--- a/include/boost/tuple/detail/tuple_basic.hpp
+++ b/include/boost/tuple/detail/tuple_basic.hpp
@@ -41,6 +41,11 @@
 
 #include "boost/detail/workaround.hpp" // needed for BOOST_WORKAROUND
 
+#if BOOST_GCC >= 40700
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
+#endif
+
 namespace boost {
 namespace tuples {
 
@@ -973,6 +978,11 @@ inline void swap(tuple<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>& lhs,
 
 } // end of namespace tuples
 } // end of namespace boost
+
+
+#if BOOST_GCC >= 40700
+#pragma GCC diagnostic pop
+#endif
 
 
 #endif // BOOST_TUPLE_BASIC_HPP


### PR DESCRIPTION
fix warning:

```
../../../boost/tuple/detail/tuple_basic.hpp: In function ‘typename boost::tuples::access_traits<typename boost::tuples::element<N, boost::tuples::cons<HT, TT> >::type>::const_type boost::tuples::get(const boost::tuples::cons<HT, TT>&)’:
../../../boost/tuple/detail/tuple_basic.hpp:228:45: warning: typedef ‘cons_element’ locally defined but not used [-Wunused-local-typedefs]
   typedef BOOST_DEDUCED_TYPENAME impl::type cons_element;
```
