### PR TITLE
Remove unused local typedef

### DIFF
--- a/include/boost/tuple/detail/tuple_basic.hpp
+++ b/include/boost/tuple/detail/tuple_basic.hpp
@@ -225,7 +225,6 @@ inline typename access_traits<
 get(const cons<HT, TT>& c) {
   typedef BOOST_DEDUCED_TYPENAME detail::drop_front<N>::BOOST_NESTED_TEMPLATE
       apply<cons<HT, TT> > impl;
-  typedef BOOST_DEDUCED_TYPENAME impl::type cons_element;
   return impl::call(c).head;
 }
 


### PR DESCRIPTION
Remove unused function-local typedef to avoid warnings with GCC 4.8.
