### PR TITLE
Make tuple constructor explicit

### DIFF
--- a/include/boost/tuple/detail/tuple_basic.hpp
+++ b/include/boost/tuple/detail/tuple_basic.hpp
@@ -484,7 +484,7 @@ public:
 // access_traits<T>::parameter_type takes non-reference types as const T&
   tuple() {}
 
-  tuple(typename access_traits<T0>::parameter_type t0)
+  explicit tuple(typename access_traits<T0>::parameter_type t0)
     : inherited(t0, detail::cnull(), detail::cnull(), detail::cnull(),
                 detail::cnull(), detail::cnull(), detail::cnull(),
                 detail::cnull(), detail::cnull(), detail::cnull()) {}


### PR DESCRIPTION
Otherwise everything implicitly convertible to the data type of the first element is implicitly convertible to a boost::tuple, which has led to long-unnoticed bugs in production code. This change is also consistent with the TR1 and C++11 tuple.
