### PR TITLE
defined tuple_size/tuple_element as class

### DIFF
--- a/include/boost/tuple/tuple.hpp
+++ b/include/boost/tuple/tuple.hpp
@@ -74,28 +74,28 @@ namespace std
 // std::tuple_size
 
 template<class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10>
-    struct tuple_size< boost::tuples::tuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> >:
-        boost::tuples::length< boost::tuples::tuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> >
+    class tuple_size< boost::tuples::tuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> >:
+        public boost::tuples::length< boost::tuples::tuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> >
 {
 };
 
-template<class H, class T> struct tuple_size< boost::tuples::cons<H, T> >: boost::tuples::length< boost::tuples::cons<H, T> >
+template<class H, class T> class tuple_size< boost::tuples::cons<H, T> >: public boost::tuples::length< boost::tuples::cons<H, T> >
 {
 };
 
-template<> struct tuple_size< boost::tuples::null_type >: boost::tuples::length< boost::tuples::null_type >
+template<> class tuple_size< boost::tuples::null_type >: public boost::tuples::length< boost::tuples::null_type >
 {
 };
 
 // std::tuple_element
 
 template<std::size_t I, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10>
-    struct tuple_element< I, boost::tuples::tuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> >:
-        boost::tuples::element< I, boost::tuples::tuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> >
+    class tuple_element< I, boost::tuples::tuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> >:
+        public boost::tuples::element< I, boost::tuples::tuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> >
 {
 };
 
-template<std::size_t I, class H, class T> struct tuple_element< I, boost::tuples::cons<H, T> >: boost::tuples::element< I, boost::tuples::cons<H, T> >
+template<std::size_t I, class H, class T> class tuple_element< I, boost::tuples::cons<H, T> >: public boost::tuples::element< I, boost::tuples::cons<H, T> >
 {
 };
 


### PR DESCRIPTION
clang with libc++ does warn about struct, since it is declared as class in libc++.

I found:
https://groups.google.com/a/isocpp.org/forum/#!topic/std-discussion/QC-AMb5oO1w

if I understand the thread correctly, MSVC also requires class, while GCC doesn't care.