### PR TITLE
Fix -Wdeprecated-copy warning with gcc 9.

### DIFF
--- a/include/boost/tuple/detail/tuple_basic.hpp
+++ b/include/boost/tuple/detail/tuple_basic.hpp
@@ -310,6 +310,7 @@ struct cons {
       tail (t2, t3, t4, t5, t6, t7, t8, t9, t10, detail::cnull())
       {}
 
+  cons( const cons& u ) : head(u.head), tail(u.tail) {}
 
   template <class HT2, class TT2>
   cons( const cons<HT2, TT2>& u ) : head(u.head), tail(u.tail) {}
@@ -388,6 +389,8 @@ struct cons<HT, null_type> {
        const null_type&, const null_type&, const null_type&,
        const null_type&, const null_type&, const null_type&)
   : head () {}
+
+  cons( const cons& u ) : head(u.head) {}
 
   template <class HT2>
   cons( const cons<HT2, null_type>& u ) : head(u.head) {}


### PR DESCRIPTION
Hi,

This fixes a -Wdeprecated-copy warning with gcc 9, because copy assignment is explicit, but copy constructor is not.

Cheers,
Romain