### PR TITLE
Fix narrowing conversion in tuple_manipulator constructor

### DIFF
--- a/include/boost/tuple/tuple_io.hpp
+++ b/include/boost/tuple/tuple_io.hpp
@@ -102,7 +102,7 @@ class tuple_manipulator {
   CharType f_c;
 public:
   explicit tuple_manipulator(detail::format_info::manipulator_type m,
-                             const char c = 0)
+                             CharType c = CharType())
      : mt(m), f_c(c) {}
 
    template<class CharTrait>


### PR DESCRIPTION
This fixes unnecessary, possibly wrapping conversion of the character argument of tuple manipulators on `tuple_manipulator` construction. This should silence MSVC warning C4244:

```
tuple_io.hpp(142,71): warning C4244:  'argument': conversion from 'const CharType' to 'const char', possible loss of data
```

Related to https://github.com/boostorg/filesystem/issues/118.