### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,6 @@ target_link_libraries(boost_tuple
   INTERFACE
     Boost::config
     Boost::core
-    Boost::static_assert
     Boost::type_traits
 )
 

--- a/build.jam
+++ b/build.jam
@@ -8,7 +8,6 @@ require-b2 5.2 ;
 constant boost_dependencies :
     /boost/config//boost_config
     /boost/core//boost_core
-    /boost/static_assert//boost_static_assert
     /boost/type_traits//boost_type_traits ;
 
 project /boost/tuple ;

--- a/test/cmake_subdir_test/CMakeLists.txt
+++ b/test/cmake_subdir_test/CMakeLists.txt
@@ -14,7 +14,6 @@ set(deps
 
 config
 core
-static_assert
 type_traits
 
 # Secondary dependencies


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.